### PR TITLE
gitignore an rstudio project file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 tests/testthat/mtcars.rds
 inst/doc
 inst/web
+*.Rproj


### PR DESCRIPTION
thought i'd open this in Rstudio, but in order to keep git clean either .gitignore should change or the .Rproj file should be added. Not sure which was the least unacceptable 